### PR TITLE
Adds an excuse counter to gulp test

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,5 @@
 For testing:  
-`npm install gulp`  
-`npm install gulp-nodemon`  
-`npm install gulp-env`  
+`npm install`  
 `gulp test`  
 
 

--- a/test/api.js
+++ b/test/api.js
@@ -20,13 +20,34 @@ describe('server functionality', function() {
 
         var excuses = results.body;
         var categoryCounter = 0;
+        var totalEx = 0;
 
         console.log('List of all categories: ');
         for (var category in excuses) {
           categoryCounter++;
           categories.push(category);
           console.log(`${categoryCounter}. ${category}`);
+          //console.log(excuses[category]);
+
+
+          for(var sub in excuses[category]) {
+            var counterEx = 0;
+            for(var ex in excuses[category][sub]){
+              counterEx++;
+            }
+            totalEx = totalEx + counterEx;
+            console.log(`     ${sub}: ${counterEx} excuses`);
+
+            //console.log(counter);
+          }
         }
+        console.log(`Total Excuses: ${totalEx}`)
+        // for (var sub in categories) {
+        //     console.log(`   this is the subgenre:  ${categories[sub]}`)
+        // }
+        //console.log(categories);
+        //console.log('This is the categories array: ' + categories);
+
         excuses.should.have.property('school' && 'events' && 'funny' && 'love' && 'social' && 'work');
         done();
       })// end of end


### PR DESCRIPTION
Now when running gulp test, the console will log all categories, subgenres and the number of excuses in each subgenre and a grand total
